### PR TITLE
issue-#28-fix-simple-typo-and-unused-library-import

### DIFF
--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -1,5 +1,5 @@
 <h1>NG-Pokédex</h1>
-<p>A open source Pokédex</p>
+<p>An open source Pokédex</p>
 <ul>
   <li>Open Source built with <a href="https://angular.io">Angular</a></li>
   <li>Data and sprites from the <a href="https://pokeapi.co/">https://pokeapi.co/</a> and

--- a/src/app/pokemon/pokemon-list/pokemon.service.ts
+++ b/src/app/pokemon/pokemon-list/pokemon.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { Observable, Subject } from 'rxjs';
-import { switchMap, startWith, tap, map } from 'rxjs/operators';
+import { switchMap, startWith, map } from 'rxjs/operators';
 
 import { Pokemon } from './../../common/interfaces/pokemon';
 import { PokemonDataService } from '../../common/services/pokemon-data.service';


### PR DESCRIPTION
- `A open source Pokédex` in about.component.html
I think we can modify it to `An open source Pokédex`
- `import { switchMap, startWith, tap, map } from 'rxjs/operators';` in pokemon.service.ts
tap is not used, so removed it